### PR TITLE
Fixed warnings

### DIFF
--- a/docs/CleanupDirPipe{I}.md
+++ b/docs/CleanupDirPipe{I}.md
@@ -6,8 +6,10 @@ public class CleanupDirPipe<I> : IPipe<I, I>
 Cleans up a given directory by deleting and re-creating it.
 
 ## Methods
-### [Run(I)](../src/Core/Pipes/IO/CleanupDirPipe.cs#L8)
+### [Run(I)](../src/Core/Pipes/IO/CleanupDirPipe.cs#L9)
 ```cs
 public Task<I> Run(I input)
 ```
+
+Asynchronously processes the specified input and returns the output.
 

--- a/docs/DocComment.md
+++ b/docs/DocComment.md
@@ -27,7 +27,7 @@ The sequence of nodes this comment consists of (e.g. `summary`, `remarks`, etc.)
 public DocCommentElement? Param(string name)
 ```
 
-A nested <param>documentation element that has the specified name.
+A nested `<param>` documentation element that has the specified name.
 
 #### Parameters
 - `name`: The name of the parameter to search inside the comment.
@@ -37,7 +37,7 @@ A nested <param>documentation element that has the specified name.
 public DocCommentElement? TypeParam(string name)
 ```
 
-A nested <typeparam>documentation element that has the specified name.
+A nested `<typeparam>` documentation element that has the specified name.
 
 #### Parameters
 - `name`: The name of the parameter to search inside the comment.

--- a/docs/DocCommentElement.md
+++ b/docs/DocCommentElement.md
@@ -1,4 +1,4 @@
-# [Summary.DocCommentElement](../src/Core/DocCommentElement.cs#L11)
+# [Summary.DocCommentElement](../src/Core/DocCommentElement.cs#L12)
 ```cs
 public record DocCommentElement(string Name, DocCommentElementAttribute[] Attributes, DocCommentNode[] Nodes) : DocCommentNode
 ```
@@ -8,19 +8,21 @@ A [`DocCommentNode`](./DocCommentNode.md) that represents a compound element (e.
 _Each element can contain simple text as well as other elements._
 
 ## Properties
-### [Name](../src/Core/DocCommentElement.cs#L11)
+### [Name](../src/Core/DocCommentElement.cs#L12)
 ```cs
 public string Name { get; }
 ```
 
 The name of the element (e.g. `remarks`, `summary`, `example`).
 
-### [Attributes](../src/Core/DocCommentElement.cs#L11)
+### [Attributes](../src/Core/DocCommentElement.cs#L12)
 ```cs
 public DocCommentElementAttribute[] Attributes { get; }
 ```
 
-### [Nodes](../src/Core/DocCommentElement.cs#L11)
+The sequence of element attributes (e.g. `name`, `cref`).
+
+### [Nodes](../src/Core/DocCommentElement.cs#L12)
 ```cs
 public DocCommentNode[] Nodes { get; }
 ```

--- a/docs/DocCommentParamRef.md
+++ b/docs/DocCommentParamRef.md
@@ -1,15 +1,16 @@
-# [Summary.DocCommentParamRef](../src/Core/DocCommentParamRef.cs#L7)
+# [Summary.DocCommentParamRef](../src/Core/DocCommentParamRef.cs#L8)
 ```cs
 public record DocCommentParamRef(string Value) : DocCommentNode
 ```
 
-A [`DocCommentNode`](./DocCommentNode.md) that represents the reference to a parameter (`<paramref>`, `<typeparamref>`).
+A [`DocCommentNode`](./DocCommentNode.md) that represents the reference to a parameter
+(`<paramref>`, `<typeparamref>`).
 
 ## Properties
-### [Value](../src/Core/DocCommentParamRef.cs#L7)
+### [Value](../src/Core/DocCommentParamRef.cs#L8)
 ```cs
 public string Value { get; }
 ```
 
-The name of the parameter .
+The name of the parameter.
 

--- a/docs/DocTypeDeclaration.md
+++ b/docs/DocTypeDeclaration.md
@@ -3,8 +3,8 @@
 public record DocTypeDeclaration : DocMember
 ```
 
-A [`DocMember`](./DocMember.md) that represents a documented type declaration (e.g. `struct`, `class`, etc.)
-in the parsed source code.
+A [`DocMember`](./DocMember.md) that represents a documented type declaration
+(e.g. `struct`, `class`, etc.) in the parsed source code.
 
 ## Properties
 ### [Members](../src/Core/DocTypeDeclaration.cs#L14)

--- a/docs/FilterMemberPipe.md
+++ b/docs/FilterMemberPipe.md
@@ -6,8 +6,10 @@ public class FilterMemberPipe : IPipe<Doc, Doc>
 A simple pipe that filters all members inside the document using the specified predicate.
 
 ## Methods
-### [Run(Doc)](../src/Core/Pipes/Filters/FilterMemberPipe.cs#L8)
+### [Run(Doc)](../src/Core/Pipes/Filters/FilterMemberPipe.cs#L9)
 ```cs
 public Task<Doc> Run(Doc input)
 ```
+
+Asynchronously processes the specified input and returns the output.
 

--- a/docs/FoldPipe{O}.md
+++ b/docs/FoldPipe{O}.md
@@ -6,8 +6,10 @@ public class FoldPipe<O> : IPipe<O[], O>
 A [`IPipe{I,O}`](./IPipe{I,O}.md) that aggregates the result of the specified pipe.
 
 ## Methods
-### [Run(O[])](../src/Core/Pipes/FoldPipe.cs#L8)
+### [Run(O[])](../src/Core/Pipes/FoldPipe.cs#L9)
 ```cs
 public Task<O> Run(O[] input)
 ```
+
+Asynchronously processes the specified input and returns the output.
 

--- a/docs/FuncPipe{I,O}.md
+++ b/docs/FuncPipe{I,O}.md
@@ -6,8 +6,10 @@ public class FuncPipe<I, O> : IPipe<I, O>
 A [`IPipe{I,O}`](./IPipe{I,O}.md) that wraps [`Func{I,O}`](./Func{I,O}.md).
 
 ## Methods
-### [Run(I)](../src/Core/Pipes/FuncPipe.cs#L16)
+### [Run(I)](../src/Core/Pipes/FuncPipe.cs#L21)
 ```cs
 public Task<O> Run(I input)
 ```
+
+Asynchronously processes the specified input and returns the output.
 

--- a/docs/IInheritDocBase.md
+++ b/docs/IInheritDocBase.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.IInheritDocBase](../src/Core/Samples/InheritDocSample.cs#L185)
+# [Summary.Samples.IInheritDocBase](../src/Core/Samples/InheritDocSample.cs#L195)
 ```cs
 public interface IInheritDocBase
 ```

--- a/docs/InheritDocBase.md
+++ b/docs/InheritDocBase.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.InheritDocBase](../src/Core/Samples/InheritDocSample.cs#L9)
+# [Summary.Samples.InheritDocBase](../src/Core/Samples/InheritDocSample.cs#L19)
 ```cs
 public class InheritDocBase
 ```
@@ -8,7 +8,7 @@ Summary.
 _Remarks section._
 
 ## Delegates
-### [Delegate1(int, int)](../src/Core/Samples/InheritDocSample.cs#L17)
+### [Delegate1(int, int)](../src/Core/Samples/InheritDocSample.cs#L27)
 ```cs
 public void Delegate1(int x, int y)
 ```
@@ -22,7 +22,7 @@ A sample delegate.
 #### Returns
 Nothing.
 
-### [Delegate2(int, int)](../src/Core/Samples/InheritDocSample.cs#L20)
+### [Delegate2(int, int)](../src/Core/Samples/InheritDocSample.cs#L30)
 ```cs
 public void Delegate2(int x, int y)
 ```
@@ -36,13 +36,13 @@ A sample delegate.
 #### Returns
 Nothing.
 
-### [Delegate3(int, int)](../src/Core/Samples/InheritDocSample.cs#L23)
+### [Delegate3(int, int)](../src/Core/Samples/InheritDocSample.cs#L33)
 ```cs
 public void Delegate3(int x, int y)
 ```
 
 ## Events
-### [Event1](../src/Core/Samples/InheritDocSample.cs#L56)
+### [Event1](../src/Core/Samples/InheritDocSample.cs#L66)
 ```cs
 public virtual event Action Event1
 ```
@@ -50,14 +50,14 @@ public virtual event Action Event1
 An event.
 
 ## Fields
-### [Field1](../src/Core/Samples/InheritDocSample.cs#L28)
+### [Field1](../src/Core/Samples/InheritDocSample.cs#L38)
 ```cs
 public int Field1
 ```
 
 A field.
 
-### [Field2](../src/Core/Samples/InheritDocSample.cs#L31)
+### [Field2](../src/Core/Samples/InheritDocSample.cs#L41)
 ```cs
 public int Field2
 ```
@@ -65,7 +65,7 @@ public int Field2
 A field.
 
 ## Properties
-### [Property1](../src/Core/Samples/InheritDocSample.cs#L39)
+### [Property1](../src/Core/Samples/InheritDocSample.cs#L49)
 ```cs
 public virtual int Property1 { get; set; }
 ```
@@ -74,7 +74,7 @@ A property.
 
 _Property remarks._
 
-### [Property2](../src/Core/Samples/InheritDocSample.cs#L42)
+### [Property2](../src/Core/Samples/InheritDocSample.cs#L52)
 ```cs
 public virtual int Property2 { get; set; }
 ```
@@ -83,7 +83,7 @@ A property.
 
 _Property remarks._
 
-### [Property3](../src/Core/Samples/InheritDocSample.cs#L45)
+### [Property3](../src/Core/Samples/InheritDocSample.cs#L55)
 ```cs
 public int Property3 { get; set; }
 ```
@@ -93,7 +93,7 @@ A property.
 _Property remarks._
 
 ## Indexers
-### [this[int]](../src/Core/Samples/InheritDocSample.cs#L51)
+### [this[int]](../src/Core/Samples/InheritDocSample.cs#L61)
 ```cs
 public virtual int this[int i] { get; }
 ```
@@ -104,7 +104,7 @@ An indexer.
 - `i`: A parameter to the indexer.
 
 ## Methods
-### [Sum(int, int)](../src/Core/Samples/InheritDocSample.cs#L64)
+### [Sum(int, int)](../src/Core/Samples/InheritDocSample.cs#L74)
 ```cs
 public virtual int Sum(int x, int y)
 ```
@@ -118,7 +118,7 @@ Calculates the sum.
 #### Returns
 Returns the sum of two values.
 
-### [Sum<T>(byte, byte)](../src/Core/Samples/InheritDocSample.cs#L73)
+### [Sum<T>(byte, byte)](../src/Core/Samples/InheritDocSample.cs#L83)
 ```cs
 public byte Sum<T>(byte x, byte y)
 ```
@@ -135,7 +135,7 @@ Calculates the byte sum.
 #### Returns
 Returns the sum of two values.
 
-### [Sum(short, short)](../src/Core/Samples/InheritDocSample.cs#L76)
+### [Sum(short, short)](../src/Core/Samples/InheritDocSample.cs#L86)
 ```cs
 public short Sum(short x, short y)
 ```
@@ -149,7 +149,7 @@ Calculates the byte sum.
 #### Returns
 Returns the sum of two values.
 
-### [Sum2(short, short)](../src/Core/Samples/InheritDocSample.cs#L79)
+### [Sum2(short, short)](../src/Core/Samples/InheritDocSample.cs#L89)
 ```cs
 public short Sum2(short x, short y)
 ```
@@ -163,7 +163,7 @@ Calculates the byte sum.
 #### Returns
 Returns the sum of two values.
 
-### [Sum3(short, short)](../src/Core/Samples/InheritDocSample.cs#L82)
+### [Sum3(short, short)](../src/Core/Samples/InheritDocSample.cs#L92)
 ```cs
 public short Sum3(short x, short y)
 ```
@@ -177,7 +177,7 @@ Calculates the byte sum.
 #### Returns
 Returns the sum of two values.
 
-### [Sum4(short, short)](../src/Core/Samples/InheritDocSample.cs#L85)
+### [Sum4(short, short)](../src/Core/Samples/InheritDocSample.cs#L95)
 ```cs
 public short Sum4(short x, short y)
 ```

--- a/docs/InheritDocRecordBase.md
+++ b/docs/InheritDocRecordBase.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.InheritDocRecordBase](../src/Core/Samples/InheritDocSample.cs#L194)
+# [Summary.Samples.InheritDocRecordBase](../src/Core/Samples/InheritDocSample.cs#L204)
 ```cs
 public record InheritDocRecordBase(int Property)
 ```
@@ -6,7 +6,7 @@ public record InheritDocRecordBase(int Property)
 Summary (record).
 
 ## Properties
-### [Property](../src/Core/Samples/InheritDocSample.cs#L194)
+### [Property](../src/Core/Samples/InheritDocSample.cs#L204)
 ```cs
 public int Property { get; }
 ```

--- a/docs/InheritDocRecordBase_Child.md
+++ b/docs/InheritDocRecordBase_Child.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.InheritDocRecordBase_Child](../src/Core/Samples/InheritDocSample.cs#L198)
+# [Summary.Samples.InheritDocRecordBase_Child](../src/Core/Samples/InheritDocSample.cs#L208)
 ```cs
 public record InheritDocRecordBase_Child(int Property, int OtherProperty) : InheritDocRecordBase(Property)
 ```
@@ -6,14 +6,14 @@ public record InheritDocRecordBase_Child(int Property, int OtherProperty) : Inhe
 Summary (record).
 
 ## Properties
-### [Property](../src/Core/Samples/InheritDocSample.cs#L198)
+### [Property](../src/Core/Samples/InheritDocSample.cs#L208)
 ```cs
 public int Property { get; }
 ```
 
 A property.
 
-### [OtherProperty](../src/Core/Samples/InheritDocSample.cs#L198)
+### [OtherProperty](../src/Core/Samples/InheritDocSample.cs#L208)
 ```cs
 public int OtherProperty { get; }
 ```

--- a/docs/InheritDoc_Child.md
+++ b/docs/InheritDoc_Child.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.InheritDoc_Child](../src/Core/Samples/InheritDocSample.cs#L89)
+# [Summary.Samples.InheritDoc_Child](../src/Core/Samples/InheritDocSample.cs#L99)
 ```cs
 public class InheritDoc_Child : InheritDocBase
 ```
@@ -8,7 +8,7 @@ Summary.
 _Remarks section._
 
 ## Events
-### [Event1](../src/Core/Samples/InheritDocSample.cs#L98)
+### [Event1](../src/Core/Samples/InheritDocSample.cs#L108)
 ```cs
 public override event Action Event1
 ```
@@ -16,7 +16,7 @@ public override event Action Event1
 An event.
 
 ## Properties
-### [Property1](../src/Core/Samples/InheritDocSample.cs#L92)
+### [Property1](../src/Core/Samples/InheritDocSample.cs#L102)
 ```cs
 public override int Property1 { get; set; }
 ```
@@ -26,7 +26,7 @@ A property.
 _Property remarks._
 
 ## Indexers
-### [this[int]](../src/Core/Samples/InheritDocSample.cs#L95)
+### [this[int]](../src/Core/Samples/InheritDocSample.cs#L105)
 ```cs
 public override int this[int i] { get; }
 ```
@@ -37,7 +37,7 @@ An indexer.
 - `i`: A parameter to the indexer.
 
 ## Methods
-### [Sum(int, int)](../src/Core/Samples/InheritDocSample.cs#L101)
+### [Sum(int, int)](../src/Core/Samples/InheritDocSample.cs#L111)
 ```cs
 public override int Sum(int x, int y)
 ```

--- a/docs/InheritDoc_Child2.md
+++ b/docs/InheritDoc_Child2.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.InheritDoc_Child2](../src/Core/Samples/InheritDocSample.cs#L105)
+# [Summary.Samples.InheritDoc_Child2](../src/Core/Samples/InheritDocSample.cs#L115)
 ```cs
 public class InheritDoc_Child2 : InheritDoc_Child
 ```
@@ -8,28 +8,28 @@ Summary.
 _Remarks section._
 
 ## Events
-### [Event1](../src/Core/Samples/InheritDocSample.cs#L123)
+### [Event1](../src/Core/Samples/InheritDocSample.cs#L133)
 ```cs
 public new event Action Event1
 ```
 
 An event.
 
-### [Event2](../src/Core/Samples/InheritDocSample.cs#L126)
+### [Event2](../src/Core/Samples/InheritDocSample.cs#L136)
 ```cs
 public event Action Event2
 ```
 
 An event.
 
-### [Event3](../src/Core/Samples/InheritDocSample.cs#L129)
+### [Event3](../src/Core/Samples/InheritDocSample.cs#L139)
 ```cs
 public event Action? Event3
 ```
 
 An event.
 
-### [Event4](../src/Core/Samples/InheritDocSample.cs#L129)
+### [Event4](../src/Core/Samples/InheritDocSample.cs#L139)
 ```cs
 public event Action? Event4
 ```
@@ -37,7 +37,7 @@ public event Action? Event4
 An event.
 
 ## Properties
-### [Property1](../src/Core/Samples/InheritDocSample.cs#L108)
+### [Property1](../src/Core/Samples/InheritDocSample.cs#L118)
 ```cs
 public override int Property1 { get; set; }
 ```
@@ -46,7 +46,7 @@ A property.
 
 _Property remarks._
 
-### [Property2](../src/Core/Samples/InheritDocSample.cs#L111)
+### [Property2](../src/Core/Samples/InheritDocSample.cs#L121)
 ```cs
 public override int Property2 { get; set; }
 ```
@@ -55,7 +55,7 @@ A property.
 
 _Property remarks._
 
-### [Property4](../src/Core/Samples/InheritDocSample.cs#L114)
+### [Property4](../src/Core/Samples/InheritDocSample.cs#L124)
 ```cs
 public int Property4 { get; set; }
 ```
@@ -64,7 +64,7 @@ A property.
 
 _Property remarks._
 
-### [Property5](../src/Core/Samples/InheritDocSample.cs#L117)
+### [Property5](../src/Core/Samples/InheritDocSample.cs#L127)
 ```cs
 public int Property5 { get; set; }
 ```
@@ -74,7 +74,7 @@ A property.
 _Property remarks._
 
 ## Indexers
-### [this[int]](../src/Core/Samples/InheritDocSample.cs#L120)
+### [this[int]](../src/Core/Samples/InheritDocSample.cs#L130)
 ```cs
 public override int this[int i] { get; }
 ```
@@ -85,7 +85,7 @@ An indexer.
 - `i`: A parameter to the indexer.
 
 ## Methods
-### [Sum(int, int)](../src/Core/Samples/InheritDocSample.cs#L135)
+### [Sum(int, int)](../src/Core/Samples/InheritDocSample.cs#L145)
 ```cs
 public override int Sum(int x, int y)
 ```

--- a/docs/InheritDoc_Child_OverrideSummary.md
+++ b/docs/InheritDoc_Child_OverrideSummary.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.InheritDoc_Child_OverrideSummary](../src/Core/Samples/InheritDocSample.cs#L171)
+# [Summary.Samples.InheritDoc_Child_OverrideSummary](../src/Core/Samples/InheritDocSample.cs#L181)
 ```cs
 public class InheritDoc_Child_OverrideSummary : InheritDocBase
 ```

--- a/docs/InheritDoc_Child_OverrideSummary2.md
+++ b/docs/InheritDoc_Child_OverrideSummary2.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.InheritDoc_Child_OverrideSummary2](../src/Core/Samples/InheritDocSample.cs#L177)
+# [Summary.Samples.InheritDoc_Child_OverrideSummary2](../src/Core/Samples/InheritDocSample.cs#L187)
 ```cs
 public class InheritDoc_Child_OverrideSummary2 : InheritDocBase
 ```

--- a/docs/InheritDoc_CrefBase.md
+++ b/docs/InheritDoc_CrefBase.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.InheritDoc_CrefBase](../src/Core/Samples/InheritDocSample.cs#L144)
+# [Summary.Samples.InheritDoc_CrefBase](../src/Core/Samples/InheritDocSample.cs#L154)
 ```cs
 public class InheritDoc_CrefBase
 ```
@@ -8,7 +8,7 @@ Summary.
 _Remarks._
 
 ## Methods
-### [Sum(int, int)](../src/Core/Samples/InheritDocSample.cs#L152)
+### [Sum(int, int)](../src/Core/Samples/InheritDocSample.cs#L162)
 ```cs
 public int Sum(int x, int y)
 ```
@@ -22,7 +22,7 @@ Calculates the sum.
 #### Returns
 Returns the sum of two values.
 
-### [Sum(long, long)](../src/Core/Samples/InheritDocSample.cs#L155)
+### [Sum(long, long)](../src/Core/Samples/InheritDocSample.cs#L165)
 ```cs
 public long Sum(long x, long y)
 ```
@@ -36,7 +36,7 @@ Calculates the sum.
 #### Returns
 Returns the sum of two values.
 
-### [Sum_OverrideSummary(long, long)](../src/Core/Samples/InheritDocSample.cs#L161)
+### [Sum_OverrideSummary(long, long)](../src/Core/Samples/InheritDocSample.cs#L171)
 ```cs
 public long Sum_OverrideSummary(long x, long y)
 ```

--- a/docs/InheritDoc_CrefBase_Child.md
+++ b/docs/InheritDoc_CrefBase_Child.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.InheritDoc_CrefBase_Child](../src/Core/Samples/InheritDocSample.cs#L165)
+# [Summary.Samples.InheritDoc_CrefBase_Child](../src/Core/Samples/InheritDocSample.cs#L175)
 ```cs
 public class InheritDoc_CrefBase_Child : InheritDoc_CrefBase
 ```

--- a/docs/InheritDoc_InterfaceChild.md
+++ b/docs/InheritDoc_InterfaceChild.md
@@ -1,4 +1,4 @@
-# [Summary.Samples.InheritDoc_InterfaceChild](../src/Core/Samples/InheritDocSample.cs#L188)
+# [Summary.Samples.InheritDoc_InterfaceChild](../src/Core/Samples/InheritDocSample.cs#L198)
 ```cs
 public class InheritDoc_InterfaceChild : IInheritDocBase
 ```

--- a/docs/LoggedPipe{I,O}.md
+++ b/docs/LoggedPipe{I,O}.md
@@ -8,8 +8,10 @@ A [`IPipe{I,O}`](./IPipe{I,O}.md) whose output is logged using the provided logg
 _Logging is implemented by simply beginning a new scope with the given message._
 
 ## Methods
-### [Run(I)](../src/Core/Pipes/Logging/LoggedPipe.cs#L16)
+### [Run(I)](../src/Core/Pipes/Logging/LoggedPipe.cs#L20)
 ```cs
 public Task<O> Run(I input)
 ```
+
+Asynchronously processes the specified input and returns the output.
 

--- a/docs/MarkdownTests.md
+++ b/docs/MarkdownTests.md
@@ -1,22 +1,22 @@
-# [Summary.Tests.Markdown.MarkdownTests](../src/Tests/Markdown/MarkdownTests.cs#L7)
+# [Summary.Tests.Markdown.MarkdownTests](../src/Tests/Markdown/MarkdownTests.cs#L8)
 ```cs
 public class MarkdownTests
 ```
 
 ## Methods
-### [NewLinePreserved()](../src/Tests/Markdown/MarkdownTests.cs#L10)
+### [NewLinePreserved()](../src/Tests/Markdown/MarkdownTests.cs#L11)
 ```cs
 [Fact]
 public void NewLinePreserved()
 ```
 
-### [LinkBeforeDot()](../src/Tests/Markdown/MarkdownTests.cs#L22)
+### [LinkBeforeDot()](../src/Tests/Markdown/MarkdownTests.cs#L23)
 ```cs
 [Fact]
 public void LinkBeforeDot()
 ```
 
-### [LinkBeforeSpace()](../src/Tests/Markdown/MarkdownTests.cs#L32)
+### [LinkBeforeSpace()](../src/Tests/Markdown/MarkdownTests.cs#L33)
 ```cs
 [Fact]
 public void LinkBeforeSpace()

--- a/docs/PipeExtensions.md
+++ b/docs/PipeExtensions.md
@@ -69,19 +69,19 @@ public static IPipe<I, O> Logged<I, O>(this IPipe<I, O> self, ILoggerFactory fac
 
 Logs the execution of the given pipe using the specified logger factory.
 
-### [Logged<I, O>(IPipe<I, O>, ILoggerFactory, Func<I, string>)](../src/Core/Pipes/PipeExtensions.cs#L65)
+### [Logged<I, O>(IPipe<I, O>, ILoggerFactory, Func<I, string>)](../src/Core/Pipes/PipeExtensions.cs#L66)
 ```cs
 public static IPipe<I, O> Logged<I, O>(this IPipe<I, O> self, ILoggerFactory factory, Func<I, string> message)
 ```
 
-### [Logged<I, O>(IPipe<I, O>, ILogger, string)](../src/Core/Pipes/PipeExtensions.cs#L71)
+### [Logged<I, O>(IPipe<I, O>, ILogger, string)](../src/Core/Pipes/PipeExtensions.cs#L72)
 ```cs
 public static IPipe<I, O> Logged<I, O>(this IPipe<I, O> self, ILogger logger, string message)
 ```
 
 Logs the execution of the given pipe using the specified logger.
 
-### [Logged<I, O>(IPipe<I, O>, ILogger, Func<I, string>)](../src/Core/Pipes/PipeExtensions.cs#L74)
+### [Logged<I, O>(IPipe<I, O>, ILogger, Func<I, string>)](../src/Core/Pipes/PipeExtensions.cs#L76)
 ```cs
 public static IPipe<I, O> Logged<I, O>(this IPipe<I, O> self, ILogger logger, Func<I, string> message)
 ```

--- a/docs/RoslynParserTests.md
+++ b/docs/RoslynParserTests.md
@@ -1,22 +1,22 @@
-# [Summary.Tests.Roslyn.RoslynParserTests](../src/Tests/Roslyn/RoslynParserTests.cs#L6)
+# [Summary.Tests.Roslyn.RoslynParserTests](../src/Tests/Roslyn/RoslynParserTests.cs#L7)
 ```cs
 public class RoslynParserTests
 ```
 
 ## Methods
-### [Class()](../src/Tests/Roslyn/RoslynParserTests.cs#L9)
+### [Class()](../src/Tests/Roslyn/RoslynParserTests.cs#L10)
 ```cs
 [Fact]
 public void Class()
 ```
 
-### [Record()](../src/Tests/Roslyn/RoslynParserTests.cs#L17)
+### [Record()](../src/Tests/Roslyn/RoslynParserTests.cs#L18)
 ```cs
 [Fact]
 public void Record()
 ```
 
-### [RecordStruct()](../src/Tests/Roslyn/RoslynParserTests.cs#L25)
+### [RecordStruct()](../src/Tests/Roslyn/RoslynParserTests.cs#L26)
 ```cs
 [Fact]
 public void RecordStruct()

--- a/docs/SavePipe{I}.md
+++ b/docs/SavePipe{I}.md
@@ -6,8 +6,10 @@ public class SavePipe<I> : IPipe<I, Unit>
 A [`IPipe{I,O}`](./IPipe{I,O}.md) that saves the input to the file.
 
 ## Methods
-### [Run(I)](../src/Core/Pipes/IO/SavePipe.cs#L8)
+### [Run(I)](../src/Core/Pipes/IO/SavePipe.cs#L9)
 ```cs
 public async Task<Unit> Run(I input)
 ```
+
+Asynchronously processes the specified input and returns the output.
 

--- a/docs/ScanPipe.md
+++ b/docs/ScanPipe.md
@@ -6,8 +6,10 @@ public class ScanPipe : IPipe<Unit, Source[]>
 A [`IPipe{I,O}`](./IPipe{I,O}.md) that searches specified directory (recursively) for files that match specified pattern.
 
 ## Methods
-### [Run(Unit)](../src/Core/Pipes/IO/ScanPipe.cs#L8)
+### [Run(Unit)](../src/Core/Pipes/IO/ScanPipe.cs#L9)
 ```cs
 public async Task<Source[]> Run(Unit _)
 ```
+
+Asynchronously processes the specified input and returns the output.
 

--- a/docs/TeePipe{I,O}.md
+++ b/docs/TeePipe{I,O}.md
@@ -6,8 +6,10 @@ public class TeePipe<I, O> : IPipe<I, O>
 A [`IPipe{I,O}`](./IPipe{I,O}.md) that invokes an action on the output of the pipe each time it's executed.
 
 ## Methods
-### [Run(I)](../src/Core/Pipes/TeePipe.cs#L8)
+### [Run(I)](../src/Core/Pipes/TeePipe.cs#L9)
 ```cs
 public async Task<O> Run(I input)
 ```
+
+Asynchronously processes the specified input and returns the output.
 

--- a/docs/ThenForEach{I,O1,O2}.md
+++ b/docs/ThenForEach{I,O1,O2}.md
@@ -6,8 +6,10 @@ public class ThenForEach<I, O1, O2> : IPipe<I, O2[]>
 A [`IPipe{I,O}`](./IPipe{I,O}.md) that aggregates the result of the specified pipe.
 
 ## Methods
-### [Run(I)](../src/Core/Pipes/ThenForEach.cs#L8)
+### [Run(I)](../src/Core/Pipes/ThenForEach.cs#L9)
 ```cs
 public async Task<O2[]> Run(I input)
 ```
+
+Asynchronously processes the specified input and returns the output.
 

--- a/docs/ThenPipe{I,O1,O2}.md
+++ b/docs/ThenPipe{I,O1,O2}.md
@@ -6,8 +6,10 @@ public class ThenPipe<I, O1, O2> : IPipe<I, O2>
 A [`IPipe{I,O}`](./IPipe{I,O}.md) that composes two pipes together.
 
 ## Methods
-### [Run(I)](../src/Core/Pipes/ThenPipe.cs#L8)
+### [Run(I)](../src/Core/Pipes/ThenPipe.cs#L9)
 ```cs
 public async Task<O2> Run(I i)
 ```
+
+Asynchronously processes the specified input and returns the output.
 

--- a/src/Core/AccessModifier.cs
+++ b/src/Core/AccessModifier.cs
@@ -9,22 +9,22 @@
 public enum AccessModifier
 {
     /// <summary>
-    ///     The `private` keyword access modifier.
+    ///     The <c>private</c> keyword access modifier.
     /// </summary>
     Private,
 
     /// <summary>
-    ///     The `protected` keyword access modifier.
+    ///     The <c>protected</c> keyword access modifier.
     /// </summary>
     Protected,
 
     /// <summary>
-    ///     The `internal` keyword access modifier.
+    ///     The <c>internal</c> keyword access modifier.
     /// </summary>
     Internal,
 
     /// <summary>
-    ///     The `public` keyword access modifier.
+    ///     The <c>public</c> keyword access modifier.
     /// </summary>
     Public,
 }

--- a/src/Core/AccessModifier.cs
+++ b/src/Core/AccessModifier.cs
@@ -1,10 +1,10 @@
 ﻿namespace Summary;
 
 /// <summary>
-///     An access modifier of a <see cref="DocMember"/> (e.g. `private`, `public`, etc.).
+///     An access modifier of a <see cref="DocMember" /> (e.g. <c>private</c>, <c>public</c>, etc.).
 /// </summary>
 /// <remarks>
-///     The modifiers are ordered starting from the smallest one (<see cref="Private"/>).
+///     The modifiers are ordered starting from the smallest one (<see cref="Private" />).
 /// </remarks>
 public enum AccessModifier
 {

--- a/src/Core/DocComment.cs
+++ b/src/Core/DocComment.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     A documentation comment parsed from the source code.
 /// </summary>
-/// <param name="Nodes">The sequence of nodes this comment consists of (e.g. `summary`, `remarks`, etc.).</param>
+/// <param name="Nodes">The sequence of nodes this comment consists of (e.g. <c>summary</c>, <c>remarks</c>, etc.).</param>
 public record DocComment(DocCommentNode[] Nodes)
 {
     /// <summary>
@@ -12,36 +12,36 @@ public record DocComment(DocCommentNode[] Nodes)
     public static readonly DocComment Empty = new(Array.Empty<DocCommentNode>());
 
     /// <summary>
-    ///     A nested &lt;param&gt; documentation element that has the specified name.
+    ///     A nested <c>&lt;param&gt;</c> documentation element that has the specified name.
     /// </summary>
     /// <param name="name">The name of the parameter to search inside the comment.</param>
     public DocCommentElement? Param(string name) =>
         Element("param", name);
 
     /// <summary>
-    ///     A nested &lt;typeparam&gt; documentation element that has the specified name.
+    ///     A nested <c>&lt;typeparam&gt;</c> documentation element that has the specified name.
     /// </summary>
     /// <param name="name">The name of the parameter to search inside the comment.</param>
     public DocCommentElement? TypeParam(string name) =>
         Element("typeparam", name);
 
     /// <summary>
-    ///     A nested documentation element that has the specified name (e.g. `summary`, `remarks`, etc.).
+    ///     A nested documentation element that has the specified name (e.g. <c>summary</c>, <c>remarks</c>, etc.).
     /// </summary>
     /// <param name="tag">The name of the element tag to search inside the comment.</param>
-    /// <param name="name">The value of the `name` attribute of the tag.</param>
+    /// <param name="name">The value of the <c>name</c> attribute of the tag.</param>
     public DocCommentElement? Element(string tag, string name) =>
         Element(x => x.Name == tag && x.Attribute("name")?.Value == name);
 
     /// <summary>
-    ///     A nested documentation element that has the specified name (e.g. `summary`, `remarks`, etc.).
+    ///     A nested documentation element that has the specified name (e.g. <c>summary</c>, <c>remarks</c>, etc.).
     /// </summary>
     /// <param name="tag">The name of the element tag to search inside the comment.</param>
     public DocCommentElement? Element(string tag) =>
         Element(x => x.Name == tag);
 
     /// <summary>
-    ///     A nested documentation element that matches the specified predicate `p`.
+    ///     A nested documentation element that matches the specified predicate <c>p</c>.
     /// </summary>
     /// <param name="p">The predicate to apply on each nested documentation element.</param>
     public DocCommentElement? Element(Func<DocCommentElement, bool> p) =>

--- a/src/Core/DocCommentElement.cs
+++ b/src/Core/DocCommentElement.cs
@@ -3,7 +3,8 @@
 /// <summary>
 ///     A <see cref="DocCommentNode"/> that represents a compound element (e.g. summary, remarks, and other XML elements).
 /// </summary>
-/// <param name="Name">The name of the element (e.g. `remarks`, `summary`, `example`).</param>
+/// <param name="Name">The name of the element (e.g. <c>remarks</c>, <c>summary</c>, <c>example</c>).</param>
+/// <param name="Attributes">The sequence of element attributes (e.g. <c>name</c>, <c>cref</c>).</param>
 /// <param name="Nodes">The sequence of nodes this element consists of.</param>
 /// <remarks>
 ///     Each element can contain simple text as well as other elements.
@@ -12,8 +13,10 @@ public record DocCommentElement(string Name, DocCommentElementAttribute[] Attrib
 {
     internal DocComment Comment() => new(Nodes);
 
-    internal DocComment Summary() => new(new[]
-        { new DocCommentElement("summary", Array.Empty<DocCommentElementAttribute>(), Nodes) });
+    internal DocComment Summary() => new(new DocCommentNode[]
+    {
+        new DocCommentElement("summary", Array.Empty<DocCommentElementAttribute>(), Nodes),
+    });
 
     internal DocCommentElementAttribute? Attribute(string name) =>
         Attributes.FirstOrDefault(x => x.Name == name);

--- a/src/Core/DocCommentElementAttribute.cs
+++ b/src/Core/DocCommentElementAttribute.cs
@@ -1,8 +1,8 @@
 ﻿namespace Summary;
 
 /// <summary>
-///     An XML-documentation attribute (e.g. `name` in `param`, etc.).
+///     An XML-documentation attribute (e.g. <c>name</c> in <c>param</c>, etc.).
 /// </summary>
-/// <param name="Name">The name of the attribute (e.g. `name`, `cref`, etc.)</param>
-/// <param name="Value">The value of the attribute (e.g. the actual name in `name` attribute).</param>
+/// <param name="Name">The name of the attribute (e.g. <c>name</c>, <c>cref</c>, etc.)</param>
+/// <param name="Value">The value of the attribute (e.g. the actual name in <c>name</c> attribute).</param>
 public record DocCommentElementAttribute(string Name, string Value);

--- a/src/Core/DocCommentInheritDoc.cs
+++ b/src/Core/DocCommentInheritDoc.cs
@@ -2,7 +2,7 @@
 
 /// <summary>
 ///     A <see cref="DocCommentNode" /> that inherits documentation from another member
-///     (`&lt;inheritdoc&gt;`).
+///     (<c>&lt;inheritdoc&gt;</c>).
 /// </summary>
 /// <param name="Cref">An optional link to the member the documentation should be inherited from.</param>
 public record DocCommentInheritDoc(string? Cref) : DocCommentNode;

--- a/src/Core/DocCommentLink.cs
+++ b/src/Core/DocCommentLink.cs
@@ -1,7 +1,7 @@
 ﻿namespace Summary;
 
 /// <summary>
-///     A <see cref="DocCommentNode"/> that represents the link to other member (e.g. `&lt;see cref="SomeMember"/&gt;`).
+///     A <see cref="DocCommentNode"/> that represents the link to other member (e.g. <c>&lt;see cref="SomeMember"/&gt;</c>).
 /// </summary>
 /// <param name="Value">The name of the member the link links to.</param>
 /// TODO: Should the link contain a `DocMember` instead of a string?

--- a/src/Core/DocCommentParamRef.cs
+++ b/src/Core/DocCommentParamRef.cs
@@ -1,7 +1,8 @@
 ﻿namespace Summary;
 
 /// <summary>
-///     A <see cref="DocCommentNode"/> that represents the reference to a parameter (`&lt;paramref&gt;`, `&lt;typeparamref&gt;`).
+///     A <see cref="DocCommentNode"/> that represents the reference to a parameter
+///     (<c>&lt;paramref&gt;</c>, <c>&lt;typeparamref&gt;</c>).
 /// </summary>
-/// <param name="Value">The name of the parameter .</param>
+/// <param name="Value">The name of the parameter.</param>
 public record DocCommentParamRef(string Value) : DocCommentNode;

--- a/src/Core/DocMember.cs
+++ b/src/Core/DocMember.cs
@@ -8,18 +8,18 @@ namespace Summary;
 public abstract record DocMember
 {
     /// <summary>
-    ///     The fully qualified name of the member (e.g., `Summary.DocMember`).
+    ///     The fully qualified name of the member (e.g., <c>Summary.DocMember</c>).
     /// </summary>
     public required string FullyQualifiedName { get; init; }
 
     /// <summary>
-    ///     The name of the member (e.g. `public int Field` has name `Field`).
+    ///     The name of the member (e.g. <c>public int Field</c> has name <c>Field</c>).
     /// </summary>
     public required string Name { get; init; }
 
     /// <summary>
     ///     The code-snippet that contains the full declaration of the member
-    ///     (e.g. `public int Field` is a declaration of the field member `Field`).
+    ///     (e.g. <c>public int Field</c> is a declaration of the field member <c>Field</c>).
     /// </summary>
     public required string Declaration { get; init; }
 
@@ -55,7 +55,7 @@ public abstract record DocMember
     public DocLocation? Location { get; init; }
 
     /// <summary>
-    ///     Whether this member matches the specified `cref` reference.
+    ///     Whether this member matches the specified <c>cref</c> reference.
     /// </summary>
     public bool MatchesCref(string cref)
     {

--- a/src/Core/DocMethod.cs
+++ b/src/Core/DocMethod.cs
@@ -23,12 +23,12 @@ public record DocMethod : DocMember
     public required bool Delegate { get; init; } = false;
 
     /// <summary>
-    ///     The signature of the method without parameters in link format (e.g., `Sum{T}`).
+    ///     The signature of the method without parameters in link format (e.g., <c>Sum{T}</c>).
     /// </summary>
     public string SignatureWithoutParams => $"{FullyQualifiedName}{TypeParamsSignature}";
 
     /// <summary>
-    ///     The signature of the method in link format (e.g., `Sum{T}(T, T)`).
+    ///     The signature of the method in link format (e.g., <c>Sum{T}(T, T)</c>).
     /// </summary>
     public string Signature => $"{SignatureWithoutParams}{ParamsSignature}";
 

--- a/src/Core/DocParam.cs
+++ b/src/Core/DocParam.cs
@@ -8,7 +8,7 @@
 public record DocParam(DocType? Type, string Name)
 {
     /// <summary>
-    ///     The comment of the parameter (i.e., `&lt;param&gt;` tag).
+    ///     The comment of the parameter (i.e., <c>&lt;param&gt;</c> tag).
     /// </summary>
     public DocCommentElement? Comment(DocMember parent) =>
         parent.Comment.Param(Name);

--- a/src/Core/DocType.cs
+++ b/src/Core/DocType.cs
@@ -3,7 +3,7 @@
 namespace Summary;
 
 /// <summary>
-///     A simple type (e.g. `int`, `string`, `List&lt;int&gt;`, etc.).
+///     A simple type (e.g. <c>int</c>, <c>string</c>, <c>List&lt;int&gt;</c>, etc.).
 /// </summary>
 /// <param name="Name">The name of the type (without generic arguments).</param>
 /// <param name="TypeParams">The generic parameters of this type (if it's generic).</param>

--- a/src/Core/DocTypeDeclaration.cs
+++ b/src/Core/DocTypeDeclaration.cs
@@ -3,8 +3,8 @@
 namespace Summary;
 
 /// <summary>
-///     A <see cref="DocMember" /> that represents a documented type declaration (e.g. `struct`, `class`, etc.)
-///     in the parsed source code.
+///     A <see cref="DocMember" /> that represents a documented type declaration
+///     (e.g. <c>struct</c>, <c>class</c>, etc.) in the parsed source code.
 /// </summary>
 public record DocTypeDeclaration : DocMember
 {

--- a/src/Core/DocTypeParam.cs
+++ b/src/Core/DocTypeParam.cs
@@ -7,7 +7,7 @@
 public record DocTypeParam(string Name)
 {
     /// <summary>
-    ///     The comment of the parameter (i.e., `&lt;typeparam&gt;` tag).
+    ///     The comment of the parameter (i.e., <c>&lt;typeparam&gt;</c> tag).
     /// </summary>
     public DocCommentElement? Comment(DocMember parent) =>
         parent.Comment.TypeParam(Name);

--- a/src/Core/Extensions/EnumerableExtensions.cs
+++ b/src/Core/Extensions/EnumerableExtensions.cs
@@ -20,13 +20,13 @@ internal static class EnumerableExtensions
         string.Join(with, self);
 
     /// <summary>
-    ///     Filters out all `null` values from the specified sequence.
+    ///     Filters out all <c>null</c> values from the specified sequence.
     /// </summary>
     public static IEnumerable<T> NonNulls<T>(this IEnumerable<T?> self) =>
         self.Where(x => x != null)!;
 
     /// <summary>
-    ///     Applies the specified `map` function on each element in the specified sequence.
+    ///     Applies the specified <c>map</c> function on each element in the specified sequence.
     ///     Additionally, passes the optional next element.
     /// </summary>
     public static IEnumerable<V> SelectWithNext<T, V>(this IEnumerable<T> self, Func<T, T?, V> map) =>

--- a/src/Core/Extensions/StringExtensions.cs
+++ b/src/Core/Extensions/StringExtensions.cs
@@ -33,7 +33,7 @@ internal static class StringExtensions
         Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, self));
 
     /// <summary>
-    ///     Converts the given string into the format of `cref` attribute value.
+    ///     Converts the given string into the format of <c>cref</c> attribute value.
     /// </summary>
     /// <example>
     ///     In the following example, the <c>"Some&lt;T1, T2&gt;"</c> string

--- a/src/Core/Pipes/Filters/FilterMemberPipe.cs
+++ b/src/Core/Pipes/Filters/FilterMemberPipe.cs
@@ -5,6 +5,7 @@ namespace Summary.Pipes.Filters;
 /// </summary>
 public class FilterMemberPipe(Predicate<DocMember> p) : IPipe<Doc, Doc>
 {
+    /// <inheritdoc />
     public Task<Doc> Run(Doc input) =>
         Task.FromResult(new Doc(Filtered(input.Members)));
 

--- a/src/Core/Pipes/FoldPipe.cs
+++ b/src/Core/Pipes/FoldPipe.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public class FoldPipe<O>(Func<O, O, O> fold, O @default) : IPipe<O[], O>
 {
+    /// <inheritdoc />
     public Task<O> Run(O[] input) =>
         Task.FromResult(input.Length is 0 ? @default : input.Aggregate(fold));
 }

--- a/src/Core/Pipes/FuncPipe.cs
+++ b/src/Core/Pipes/FuncPipe.cs
@@ -7,12 +7,17 @@ public class FuncPipe<I, O> : IPipe<I, O>
 {
     private readonly Func<I, Task<O>> _func;
 
+    /// <inheritdoc cref="FuncPipe{I,O}(Func{I,Task{O}})" />
     public FuncPipe(Func<I, O> func) =>
         _func = i => Task.FromResult(func(i));
 
+    /// <summary>
+    ///     Initializes a pipe.
+    /// </summary>
     public FuncPipe(Func<I, Task<O>> func) =>
         _func = func;
 
+    /// <inheritdoc />
     public Task<O> Run(I input) =>
         _func(input);
 }

--- a/src/Core/Pipes/IO/CleanupDirPipe.cs
+++ b/src/Core/Pipes/IO/CleanupDirPipe.cs
@@ -5,6 +5,7 @@ namespace Summary.Pipes.IO;
 /// </summary>
 public class CleanupDirPipe<I>(string root) : IPipe<I, I>
 {
+    /// <inheritdoc />
     public Task<I> Run(I input)
     {
         if (Directory.Exists(root))

--- a/src/Core/Pipes/IO/SavePipe.cs
+++ b/src/Core/Pipes/IO/SavePipe.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public class SavePipe<I>(string root, Func<I, (string Path, string Content)> file) : IPipe<I, Unit>
 {
+    /// <inheritdoc />
     public async Task<Unit> Run(I input)
     {
         var (path, content) = file(input);

--- a/src/Core/Pipes/IO/ScanPipe.cs
+++ b/src/Core/Pipes/IO/ScanPipe.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public class ScanPipe(string[] sources, string pattern) : IPipe<Unit, Source[]>
 {
+    /// <inheritdoc />
     public async Task<Source[]> Run(Unit _)
     {
         // TODO: Consider refactoring this into more proper solution (@j.light).

--- a/src/Core/Pipes/Logging/LoggedPipe.cs
+++ b/src/Core/Pipes/Logging/LoggedPipe.cs
@@ -10,9 +10,13 @@ namespace Summary.Pipes.Logging;
 /// </remarks>
 public class LoggedPipe<I, O>(IPipe<I, O> inner, ILogger logger, Func<I, string> message) : IPipe<I, O>
 {
+    /// <summary>
+    ///     Initializes a pipe.
+    /// </summary>
     public LoggedPipe(IPipe<I, O> inner, ILogger logger, string message)
         : this(inner, logger, _ => message) { }
 
+    /// <inheritdoc />
     public Task<O> Run(I input)
     {
         using var _ = logger.BeginScope(message(input));

--- a/src/Core/Pipes/PipeExtensions.cs
+++ b/src/Core/Pipes/PipeExtensions.cs
@@ -62,6 +62,7 @@ public static class PipeExtensions
     public static IPipe<I, O> Logged<I, O>(this IPipe<I, O> self, ILoggerFactory factory, string message) =>
         self.Logged(factory.CreateLogger(self.GetType().Name), message);
 
+    /// <inheritdoc cref="Logged{I,O}(IPipe{I,O},ILoggerFactory,string)" />
     public static IPipe<I, O> Logged<I, O>(this IPipe<I, O> self, ILoggerFactory factory, Func<I, string> message) =>
         self.Logged(factory.CreateLogger(self.GetType().Name), message);
 
@@ -71,6 +72,7 @@ public static class PipeExtensions
     public static IPipe<I, O> Logged<I, O>(this IPipe<I, O> self, ILogger logger, string message) =>
         new LoggedPipe<I, O>(self, logger, message);
 
+    /// <inheritdoc cref="Logged{I,O}(IPipe{I,O},ILogger,string)" />
     public static IPipe<I, O> Logged<I, O>(this IPipe<I, O> self, ILogger logger, Func<I, string> message) =>
         new LoggedPipe<I, O>(self, logger, message);
 }

--- a/src/Core/Pipes/PipeExtensions.cs
+++ b/src/Core/Pipes/PipeExtensions.cs
@@ -33,13 +33,13 @@ public static class PipeExtensions
         when ? a.Then(b) : a;
 
     /// <summary>
-    ///     Constructs a new pipe that will apply the specified `select` function to the output of the current pipe.
+    ///     Constructs a new pipe that will apply the specified <c>select</c> function to the output of the current pipe.
     /// </summary>
     public static IPipe<I, O2> Then<I, O1, O2>(this IPipe<I, O1> a, Func<O1, O2> map) =>
         a.Then(new FuncPipe<O1, O2>(map));
 
     /// <summary>
-    ///     Constructs a new pipe that will apply the specified `select` function to the output of the current pipe.
+    ///     Constructs a new pipe that will apply the specified <c>select</c> function to the output of the current pipe.
     /// </summary>
     public static IPipe<I, O> Then<I, O>(this IPipe<I, O> a, Func<O, O> map, bool when) =>
         when ? a.Then(map) : a;

--- a/src/Core/Pipes/TeePipe.cs
+++ b/src/Core/Pipes/TeePipe.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public class TeePipe<I, O>(IPipe<I, O> inner, Action<O> tee) : IPipe<I, O>
 {
+    /// <inheritdoc />
     public async Task<O> Run(I input)
     {
         var output =  await inner.Run(input).ConfigureAwait(false);

--- a/src/Core/Pipes/ThenForEach.cs
+++ b/src/Core/Pipes/ThenForEach.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public class ThenForEach<I, O1, O2>(IPipe<I, O1[]> inner, IPipe<O1, O2> map) : IPipe<I, O2[]>
 {
+    /// <inheritdoc />
     public async Task<O2[]> Run(I input)
     {
         var os = await inner.Run(input).ConfigureAwait(false);

--- a/src/Core/Pipes/ThenPipe.cs
+++ b/src/Core/Pipes/ThenPipe.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public class ThenPipe<I, O1, O2>(IPipe<I, O1> a, IPipe<O1, O2> b) : IPipe<I, O2>
 {
+    /// <inheritdoc />
     public async Task<O2> Run(I i)
     {
         var x = await a.Run(i).ConfigureAwait(false);

--- a/src/Core/Pipes/Unit.cs
+++ b/src/Core/Pipes/Unit.cs
@@ -1,7 +1,7 @@
 ﻿namespace Summary.Pipes;
 
 /// <summary>
-///     A void type that is similar to `void` keyword.
+///     A void type that is similar to <c>void</c> keyword.
 /// </summary>
 public class Unit
 {

--- a/src/Core/Samples/InheritDocSample.cs
+++ b/src/Core/Samples/InheritDocSample.cs
@@ -1,4 +1,14 @@
-﻿namespace Summary.Samples;
+﻿// ReSharper disable UnusedType.Global
+// ReSharper disable UnusedMember.Global
+// ReSharper disable EventNeverInvoked.Global
+// ReSharper disable EventNeverSubscribedTo.Global
+// ReSharper disable NotAccessedPositionalProperty.Global
+#pragma warning disable CS0067
+#pragma warning disable CS1573
+#pragma warning disable CA1070
+#pragma warning disable CA1822
+
+namespace Summary.Samples;
 
 /// <summary>
 ///     Summary.
@@ -162,19 +172,19 @@ public class InheritDoc_CrefBase
 }
 
 /// <inheritdoc cref="InheritDoc_CrefBase" />
-public class InheritDoc_CrefBase_Child : InheritDoc_CrefBase { }
+public class InheritDoc_CrefBase_Child : InheritDoc_CrefBase;
 
 /// <summary>
 ///     Summary (child).
 /// </summary>
 /// <inheritdoc />
-public class InheritDoc_Child_OverrideSummary : InheritDocBase { }
+public class InheritDoc_Child_OverrideSummary : InheritDocBase;
 
 /// <inheritdoc />
 /// <summary>
 ///     Summary (child).
 /// </summary>
-public class InheritDoc_Child_OverrideSummary2 : InheritDocBase { }
+public class InheritDoc_Child_OverrideSummary2 : InheritDocBase;
 
 /// <summary>
 ///     Summary (interface).
@@ -182,10 +192,10 @@ public class InheritDoc_Child_OverrideSummary2 : InheritDocBase { }
 /// <remarks>
 ///     Remarks section (interface).
 /// </remarks>
-public interface IInheritDocBase { }
+public interface IInheritDocBase;
 
 /// <inheritdoc />
-public class InheritDoc_InterfaceChild : IInheritDocBase { }
+public class InheritDoc_InterfaceChild : IInheritDocBase;
 
 /// <summary>
 ///     Summary (record).

--- a/src/Core/Samples/Sample.cs
+++ b/src/Core/Samples/Sample.cs
@@ -102,19 +102,19 @@ public class Sample<T0, T1>
     /// <summary>
     ///     A simple method.
     ///     It contains two parameters:
-    ///     - <paramref name="x" /> means `x`
-    ///     - <paramref name="y" /> means `y`
+    ///     - <paramref name="x" /> means <c>x</c>
+    ///     - <paramref name="y" /> means <c>y</c>
     ///     It contains three type parameters:
     ///     - <typeparamref name="M0" /> is the first one
     ///     - <typeparamref name="M1" /> is the second one
     ///     - <typeparamref name="M2" /> is the third one
     /// </summary>
-    /// <param name="x">The `x` of the method.</param>
-    /// <param name="y">The `y` of the method.</param>
+    /// <param name="x">The <c>x</c> of the method.</param>
+    /// <param name="y">The <c>y</c> of the method.</param>
     /// <typeparam name="M0">The first type parameter of the method.</typeparam>
     /// <typeparam name="M1">The second type parameter of the method.</typeparam>
     /// <typeparam name="M2">The third type parameter of the method.</typeparam>
-    /// <returns>The `TimeSpan` instance.</returns>
+    /// <returns>The <c>TimeSpan</c> instance.</returns>
     public TimeSpan Method<M0, M1, M2>(int x, string y) =>
         TimeSpan.Zero;
 


### PR DESCRIPTION
- Fixed build warnings (mainly the "missing public member documentation" errors);
- Fixed documentation by replacing \` with `<c>` tags.